### PR TITLE
Potential fix for code scanning alert no. 10: Binding a socket to all network interfaces

### DIFF
--- a/model-engine/model_engine_server/inference/vllm/vllm_server.py
+++ b/model-engine/model_engine_server/inference/vllm/vllm_server.py
@@ -201,7 +201,7 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     logger.info("args: %s", args)
 
     temp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # nosemgrep
-    temp_socket.bind(("", args.port))
+    temp_socket.bind((args.host, args.port))
 
     def signal_handler(*_) -> None:
         # Interrupt server on sigterm while initializing


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/10](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/10)

To fix the problem, we need to bind the socket to a specific network interface instead of all interfaces. This can be achieved by using a specific IP address for the host. The best way to fix this without changing existing functionality is to modify the `run_server` function to bind the socket to a dedicated interface. We can achieve this by using the `args.host` parameter, which is already being used later in the function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
