### PR TITLE
Potential fix for code scanning alert no. 11: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/model-engine/model_engine_server/common/settings.py
+++ b/model-engine/model_engine_server/common/settings.py
@@ -61,7 +61,7 @@ def generate_destination(user_id: str, endpoint_name: str, endpoint_type: str) -
 
 
 def _generate_deployment_name_parts(user_id: str, endpoint_name: str) -> List[str]:
-    user_endpoint_hash = hashlib.md5((user_id + endpoint_name).encode("utf-8")).hexdigest()
+    user_endpoint_hash = hashlib.sha256((user_id + endpoint_name).encode("utf-8")).hexdigest()
     return [
         DEPLOYMENT_PREFIX,
         user_id[:24],


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/11](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/11)

To address the issue, we will replace the use of the MD5 hashing algorithm with a stronger and more secure alternative. Since the hash is used for generating unique identifiers, SHA-256 is a suitable replacement. It is a strong cryptographic hash function that is widely used and resistant to pre-image and collision attacks.

The changes involve:
1. Replacing `hashlib.md5` with `hashlib.sha256` on line 64.
2. Updating the code to ensure the hash is computed using SHA-256 and truncated to 8 characters as before.

No additional imports or dependencies are required, as `hashlib` already supports SHA-256.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
