### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/model-engine/model_engine_server/core/aws/secrets.py
+++ b/model-engine/model_engine_server/core/aws/secrets.py
@@ -26,5 +26,5 @@ def get_key_file(secret_name: str, aws_profile: Optional[str] = None):
         return secret_value
     except ClientError as e:
         logger.error(e)
-        logger.error(f"Failed to retrieve secret: {secret_name}")
+        logger.error("Failed to retrieve a secret from AWS Secrets Manager.")
         return {}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/9](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/9)

To fix the issue, we should avoid logging the `secret_name` directly. Instead, we can log a generic message that does not include sensitive information. For example, we can log that a secret retrieval failed without specifying the secret's name. This ensures that sensitive data is not exposed while still providing useful debugging information.

Changes required:
1. Replace the log message on line 29 of `model-engine/model_engine_server/core/aws/secrets.py` to exclude `secret_name`.
2. Ensure that the updated log message provides sufficient context for debugging without revealing sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
