### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/model-engine/model_engine_server/db/base.py
+++ b/model-engine/model_engine_server/db/base.py
@@ -57,7 +57,7 @@ def get_engine_url(
             env = infra_config().env
         if key_file is None:
             key_file = get_key_file_name(env)  # type: ignore
-        logger.debug(f"Using key file {key_file}")
+        logger.debug("Using a key file for database connection.")
 
         if infra_config().cloud_provider == "azure":
             client = SecretClient(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/7](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/7)

To fix the issue, we should avoid logging the value of `key_file` directly. Instead, we can log a generic message that does not include sensitive data. For example, we can log that a key file is being used without specifying its name or value. This approach ensures that no sensitive information is exposed while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
