### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/model-engine/model_engine_server/service_builder/tasks_v1.py
+++ b/model-engine/model_engine_server/service_builder/tasks_v1.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from typing import Any, Dict
+from urllib.parse import urlparse
 
 import aioredis
 from celery.signals import worker_process_init
@@ -74,7 +75,7 @@ def get_live_endpoint_builder_service(
     docker_repository: DockerRepository
     if CIRCLECI:
         docker_repository = FakeDockerRepository()
-    elif infra_config().docker_repo_prefix.endswith("azurecr.io"):
+    elif urlparse(infra_config().docker_repo_prefix).hostname.endswith(".azurecr.io"):
         docker_repository = ACRDockerRepository()
     else:
         docker_repository = ECRDockerRepository()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/5](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/5)

To fix the issue, we should parse the `docker_repo_prefix` as a URL and validate its hostname to ensure it matches the expected domain structure. Specifically, we can use Python's `urllib.parse` module to extract the hostname and then check if it ends with `.azurecr.io`. This approach ensures that the check is performed on the actual hostname, not just a substring of the URL.

The changes will involve:
1. Importing the `urlparse` function from `urllib.parse`.
2. Replacing the `endswith("azurecr.io")` check with a parsed hostname check using `urlparse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
