### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/model-engine/model_engine_server/entrypoints/populate_llm_fine_tuning_job_repository.py
+++ b/model-engine/model_engine_server/entrypoints/populate_llm_fine_tuning_job_repository.py
@@ -12,6 +12,7 @@ You will need a docker image from the fine-tuning repo. Refer to llm/finetune_pi
 """
 
 import argparse
+from urllib.parse import urlparse
 import asyncio
 
 import requests
@@ -146,7 +147,9 @@ async def main(args):
 
     if repository.startswith("s3://"):
         repo = S3FileLLMFineTuneRepository(file_path=repository)
-    elif repository.startswith("azure://") or "blob.core.windows.net" in repository:
+    elif repository.startswith("azure://") or (
+        urlparse(repository).hostname and urlparse(repository).hostname.endswith("blob.core.windows.net")
+    ):
         repo = ABSFileLLMFineTuneRepository(file_path=repository)
     else:
         raise ValueError(f"LLM fine-tune repository must be S3 or ABS file; got {repository}")


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/4](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/4)

To fix the issue, the code should parse the `repository` URL using Python's `urllib.parse` module and validate the hostname explicitly. This ensures that the check is performed on the actual hostname of the URL, rather than relying on a substring match. Specifically, the hostname should be checked to see if it matches `blob.core.windows.net` or ends with `.blob.core.windows.net` to allow for subdomains.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
