### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/model-engine/model_engine_server/api/dependencies.py
+++ b/model-engine/model_engine_server/api/dependencies.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Callable, Optional
 
 import aioredis
+from urllib.parse import urlparse
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials, OAuth2PasswordBearer
 from model_engine_server.common.config import hmi_config
@@ -343,7 +344,7 @@ def _get_external_interfaces(
     docker_repository: DockerRepository
     if CIRCLECI:
         docker_repository = FakeDockerRepository()
-    elif infra_config().docker_repo_prefix.endswith("azurecr.io"):
+    elif urlparse(infra_config().docker_repo_prefix).hostname == "azurecr.io":
         docker_repository = ACRDockerRepository()
     else:
         docker_repository = ECRDockerRepository()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/1](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/1)

To fix the issue, the code should parse the `docker_repo_prefix` as a URL and validate its hostname explicitly. This ensures that the check is performed on the actual host component of the URL, rather than relying on string matching, which is error-prone. The `urlparse` function from Python's `urllib.parse` module can be used to extract the hostname, and the validation can then confirm that the hostname matches the expected domain (`azurecr.io`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
