### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/model-engine/model_engine_server/entrypoints/populate_llm_fine_tuning_job_repository.py
+++ b/model-engine/model_engine_server/entrypoints/populate_llm_fine_tuning_job_repository.py
@@ -15,6 +15,9 @@ import argparse
 from urllib.parse import urlparse
 import asyncio
 
+def is_valid_blob_hostname(hostname):
+    # Check if the hostname is exactly "blob.core.windows.net" or a subdomain of it
+    return hostname == "blob.core.windows.net" or hostname.endswith(".blob.core.windows.net")
 import requests
 from model_engine_server.common.config import hmi_config
 from model_engine_server.domain.entities.llm_fine_tune_entity import LLMFineTuneTemplate
@@ -148,7 +151,7 @@ async def main(args):
     if repository.startswith("s3://"):
         repo = S3FileLLMFineTuneRepository(file_path=repository)
     elif repository.startswith("azure://") or (
-        urlparse(repository).hostname and urlparse(repository).hostname.endswith("blob.core.windows.net")
+        urlparse(repository).hostname and is_valid_blob_hostname(urlparse(repository).hostname)
     ):
         repo = ABSFileLLMFineTuneRepository(file_path=repository)
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/12](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/12)

To fix the issue, we need to ensure that the hostname matches the expected domain structure exactly. Instead of using `endswith`, we can compare the hostname against a predefined list of allowed hostnames or use stricter validation logic. For example, we can check if the hostname is exactly `blob.core.windows.net` or a valid subdomain of it. This can be achieved by parsing the hostname and verifying its structure.

The fix involves:
1. Parsing the hostname using `urlparse`.
2. Validating that the hostname is either `blob.core.windows.net` or a subdomain of it (e.g., `subdomain.blob.core.windows.net`).
3. Replacing the `endswith` check with this stricter validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
