### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/model-engine/model_engine_server/entrypoints/k8s_cache.py
+++ b/model-engine/model_engine_server/entrypoints/k8s_cache.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import os
 import time
+from urllib.parse import urlparse
 from typing import Any
 
 from kubernetes import config as kube_config
@@ -124,7 +125,7 @@ async def main(args: Any):
     docker_repo: DockerRepository
     if CIRCLECI:
         docker_repo = FakeDockerRepository()
-    elif infra_config().docker_repo_prefix.endswith("azurecr.io"):
+    elif urlparse(infra_config().docker_repo_prefix).hostname == "azurecr.io":
         docker_repo = ACRDockerRepository()
     else:
         docker_repo = ECRDockerRepository()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/2](https://github.com/Git-Hub-Chris/Scale-LLM-Engine/security/code-scanning/2)

To fix the issue, we should parse the `docker_repo_prefix` as a URL and validate its hostname explicitly. This ensures that the check is performed on the actual hostname rather than relying on substring matching. The `urllib.parse` module can be used to extract the hostname from the `docker_repo_prefix`. The fix involves replacing the `endswith` check with a proper hostname validation using `urlparse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
